### PR TITLE
Marketplace: Use DIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ __Note:__ the Chlu Marketplace will start and run a `js-ipfs` node when used
 
 ### Documentation
 
-Here are some generated HTML docs for the library. [Documentation](http://ipfs.io/ipfs/QmRczgn5ZEF7pLBLp4zL339p836qCAd9YLeDD1mRN2nGuz/)
+Here are some generated HTML docs for the library. [Documentation](http://ipfs.io/ipfs/QmeU6GxA7KVdnCZLKS73Fwk6XLwvnNCegfTpPv2zUnwavC/)
 
 ### Starting the HTTP Server
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ await mkt.start()
 await mkt.registerVendor(...)
 await mkt.createPoPR(...)
 ```
+
+### Quickly setup a vendor
+
+There is a non interactive command that generates a new DID, then sets it up as
+a vendor on a marketplace. Istructions are in the [chlu-wallet README](https://github.com/ChluNetwork/chlu-wallet#set-up-marketplace)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "chlu-ipfs-support": "ChluNetwork/chlu-ipfs-support",
+    "chlu-ipfs-support": "ChluNetwork/chlu-ipfs-support#did",
     "commander": "^2.15.0",
     "cors": "^2.8.4",
     "express": "^4.16.2",
@@ -78,10 +78,6 @@
       "no-console": 0,
       "no-debugger": 1,
       "no-var": 1,
-      "semi": [
-        1,
-        "always"
-      ],
       "no-trailing-spaces": 0,
       "eol-last": 0,
       "no-underscore-dangle": 0,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mkdirp": "^0.5.1",
     "morgan": "^1.9.0",
     "multihashes": "^0.4.13",
+    "rimraf": "^2.6.2",
     "sequelize": "^4.35.1",
     "sqlite3": "^3.1.13"
   },
@@ -45,7 +46,6 @@
     "mocha": "^5.0.1",
     "multihashing-async": "^0.4.8",
     "nyc": "^11.4.1",
-    "rimraf": "^2.6.2",
     "sinon": "^4.4.2",
     "supertest": "^3.0.0"
   },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -33,9 +33,9 @@ cli
     .command('setup-vendor')
     .description('set up a vendor and return the keys')
     .option('-u, --url <s>', 'URL to access the marketplace', 'http://localhost:3000')
-    .option('-k, --key-pair <s>', 'use an existing keypair in WIF format')
+    .option('-n, --network <s>', 'Chlu network to use')
     .action(handleErrors(async cmd => {
-        await vendorSetup(cmd.url, cmd.keyPair);
+        await vendorSetup(cmd.url, cmd.network);
     }));
 
 cli.parse(process.argv);

--- a/src/bin/vendorSetup.js
+++ b/src/bin/vendorSetup.js
@@ -1,75 +1,76 @@
 #!/usr/bin/env node
-const { ECPair } = require('bitcoinjs-lib');
 const ChluIPFS = require('chlu-ipfs-support');
 const axios = require('axios');
 const os = require('os');
 const path = require('path');
+const rimraf = require('rimraf')
 
 const log = msg => console.log(msg);
 
-async function vendorSetup(url = 'http://localhost:3000', wif = null) {
-    let keyPair, chluIpfs;
+const directory = path.join(os.tmpdir(), 'chlu-vendor-script')
+
+async function vendorSetup(url = 'http://localhost:3000', network) {
+    let chluIpfs;
     try {
-        log('Preparing Keys');
-        keyPair = loadKeys(wif);
         log('Preparing Chlu IPFS');
-        chluIpfs = getChluIPFS();
+        chluIpfs = getChluIPFS({ network });
         await chluIpfs.start();
+        log('Using Chlu Network ' + chluIpfs.instance.network)
+        log('Using DID ' + chluIpfs.instance.did.didId)
     } catch (error) {
         log('Could not prepare required data: ' + error.message || error);
         return;
     }
     try {
         log('Registering vendor to ' + url);
-        const multihash = await storePublicKey(chluIpfs, keyPair);
-        const { vmPubKeyMultihash } = await register(url, multihash);
-        await submitSignature(url, chluIpfs, vmPubKeyMultihash, multihash, keyPair);
+        const { vmPubKeyMultihash } = await register(url, chluIpfs.instance.did.didId);
+        await submitSignature(url, chluIpfs, vmPubKeyMultihash);
+        log('\n========= SUCCESS ==========')
     } catch (error) {
+        log('\n========== ERROR ==========')
         log('Vendor registration failed: ' + error.message || error);
+        log('========== ERROR ==========\n')
     }
+    log('Dumping Full DID Export')
+    log('\n')
+    const exported = await chluIpfs.instance.did.export()
+    const exportedString = JSON.stringify(exported, null, 2)
+    log(exportedString)
+    log('\n')
     log('Stopping gracefully');
     await chluIpfs.stop();
+    log('Deleting data');
+    rimraf.sync(directory)
+    log('Done')
+    process.exit(0) // rimraf leaves a dirty event loop!
 }
 
-function getChluIPFS() {
-    const chluIpfs = new ChluIPFS({
+function getChluIPFS(opt) {
+    const chluIpfs = new ChluIPFS(Object.assign({
         type: ChluIPFS.types.vendor,
-        directory: path.join(os.tmpdir(), 'chlu-vendor-script')
-    });
+        directory 
+    }, opt));
     return chluIpfs;
 }
 
-function loadKeys(wif) {
-    let keyPair;
-    if (wif) {
-        log('Opening keypair from WIF');
-        keyPair = ECPair.fromWIF(wif);
-    } else {
-        log('Generating keypair');
-        keyPair = ECPair.makeRandom();
-        log('Generated key pair. WIF = ' + keyPair.toWIF());
-    }
-    return keyPair;
-}
-
-async function storePublicKey(chluIpfs, keyPair) {
-    return await chluIpfs.instance.crypto.storePublicKey(keyPair.getPublicKeyBuffer());
-}
-
-async function register(url, pubKeyMultihash) {
+async function register(url, didId) {
+    log('===> Register Request for ' + didId)
     const response = await axios.post(url + '/vendors', {
-        vendorPubKeyMultihash: pubKeyMultihash
+        didId
     });
+    log('<=== Response:\n' + JSON.stringify(response.data, null, 2))
     if (response.status !== 200) throw new Error('Registering failed: server returned ' + response.status);
     return response.data;
 }
 
-async function submitSignature(url, chluIpfs, vmPubKeyMultihash, pubKeyMultihash, keyPair) {
-    const signature = await chluIpfs.instance.crypto.signMultihash(vmPubKeyMultihash, keyPair);
-    const response = await axios.post(url + '/vendors/' + pubKeyMultihash + '/signature', { signature });
+async function submitSignature(url, chluIpfs, vmPubKeyMultihash) {
+    log('===> Signature')
+    const signature = await chluIpfs.instance.did.signMultihash(vmPubKeyMultihash);
+    const response = await axios.post(url + '/vendors/' + chluIpfs.instance.did.didId + '/signature', { signature });
     if (response.status !== 200) {
         throw new Error('Submitting signature failed: server returned ' + response.status);
     }
+    log('<=== OK')
 }
 
 module.exports = vendorSetup;

--- a/src/db.js
+++ b/src/db.js
@@ -32,7 +32,7 @@ class DB {
                 operatorsAliases: false
             });
             this.Vendor = this.db.define('vendor', {
-                vmKeyPairWIF: {
+                vmPrivateKey: {
                     type: Sequelize.STRING,
                     unique: true
                 },
@@ -40,7 +40,7 @@ class DB {
                     type: Sequelize.STRING,
                     unique: true
                 },
-                vPubKeyMultihash: {
+                vDidId: {
                     type: Sequelize.STRING,
                     unique: true
                 },
@@ -63,52 +63,52 @@ class DB {
 
     async getVendorIDs() {
         const data = await this.Vendor.findAll({
-            attributes: ['vPubKeyMultihash']
+            attributes: ['vDidId']
         });
-        return data.map(d => d.vPubKeyMultihash);
+        return data.map(d => d.vDidId);
     }
 
     async getVendor(id) {
         const vendor = await this.Vendor.findOne({
             where: {
-                vPubKeyMultihash: id
+                vDidId: id
             }
         });
         if (vendor) {
             const v = vendor.toJSON();
             return {
                 mSignature: v.mSignature,
-                vPubKeyMultihash: v.vPubKeyMultihash,
+                vDidId: v.vDidId,
                 vSignature: v.vSignature,
                 vmPubKeyMultihash: v.vmPubKeyMultihash,
-                vmKeyPairWIF: v.vmKeyPairWIF
+                vmPrivateKey: v.vmPrivateKey
             };
         }
         return null;
     }
 
-    async getVMKeyPairWIF(id) {
+    async getVMPrivateKey(id) {
         const vendor = await this.Vendor.findOne({
             where: {
-                vPubKeyMultihash: id
+                vDidId: id
             }
         });
         if (vendor) {
-            return vendor.get('vmKeyPairWIF');
+            return vendor.get('vmPrivateKey');
         }
         return null;
     }
 
     async createVendor(id, data) {
         const vendor = await this.Vendor
-            .create(Object.assign({}, data, { vPubKeyMultihash: id }));
+            .create(Object.assign({}, data, { vDidId: id }));
         return vendor.toJSON();
     }
 
     async updateVendor(id, data) {
         const vendor = await this.Vendor.findOne({
             where: {
-                vPubKeyMultihash: id
+                vDidId: id
             }
         });
         if (vendor) {

--- a/src/marketplace.js
+++ b/src/marketplace.js
@@ -269,7 +269,7 @@ class Marketplace {
             const vendor = await this.getVendor(id);
             // TODO: signature needs expiration date?
             const PvmMultihash = vendor.vmPubKeyMultihash;
-            const valid = this.chluIpfs.instance.did.verifyMultihash(vDidId, PvmMultihash, signature);
+            const valid = this.chluIpfs.instance.did.verifyMultihash(vDidId, PvmMultihash, signature, true);
             if (valid) {
                 vendor.vSignature = signature;
                 await this.db.updateVendor(id, vendor);

--- a/src/server.js
+++ b/src/server.js
@@ -27,10 +27,10 @@ app.post('/vendors/:id/popr', async (req, res) => {
 });
 
 app.get('/.well-known', async (req, res) => {
-    const keys = await app.locals.mkt.getKeys();
+    const didId = await app.locals.mkt.getDIDID();
     const id = await app.locals.mkt.getIPFSID();
     await respond(res, {
-        multihash: keys.pubKeyMultihash,
+        didId,
         ipfsId: id
     });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -11,8 +11,8 @@ app.get('/vendors', async (req, res) => {
     await respond(res, app.locals.mkt.getVendorIDs());
 });
 app.post('/vendors', async (req, res) => {
-    const pubKeyMultihash = req.body.vendorPubKeyMultihash;
-    await respond(res, app.locals.mkt.registerVendor(pubKeyMultihash)); 
+    const didId = req.body.didId;
+    await respond(res, app.locals.mkt.registerVendor(didId)); 
 });
 app.post('/vendors/:id/signature', async (req, res) => {
     const signature = req.body.signature;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -9,9 +9,9 @@ describe('HTTP API', () => {
         const server = require('../src/server');
         mkt = server.locals.mkt = {
             registerVendor: sinon.stub().resolves({
-                id: 'pvmultihash',
                 vDidId: 'fakevendordidid',
-                marketplaceSignature: 'fakesignature'
+                vmPubKeyMultihash: 'fakevmmultihash',
+                mSignature: 'fakesignature'
             }),
             updateVendorSignature: sinon.stub().resolves(),
             generatePoPR: sinon.stub().resolves(),
@@ -58,14 +58,14 @@ describe('HTTP API', () => {
     it('POST /vendors', async () => {
         await api.post('/vendors')
             .send({
-                vendorPubKeyMultihash: 'pvmultihash'
+                didId: 'fakevendordidid'
             })
             .expect({
-                id: 'pvmultihash',
                 vDidId: 'fakevendordidid',
-                marketplaceSignature: 'fakesignature'
+                vmPubKeyMultihash: 'fakevmmultihash',
+                mSignature: 'fakesignature'
             });
-        expect(mkt.registerVendor.calledWith('pvmultihash')).to.be.true;
+        expect(mkt.registerVendor.calledWith('fakevendordidid')).to.be.true;
     });
 
     it('POST /vendors/ven1/signature', async () => {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -10,7 +10,7 @@ describe('HTTP API', () => {
         mkt = server.locals.mkt = {
             registerVendor: sinon.stub().resolves({
                 id: 'pvmultihash',
-                multihash: 'fakemultihash',
+                vDidId: 'fakevendordidid',
                 marketplaceSignature: 'fakesignature'
             }),
             updateVendorSignature: sinon.stub().resolves(),
@@ -19,13 +19,11 @@ describe('HTTP API', () => {
                 'ven1', 'ven2'
             ]),
             getVendor: sinon.stub().resolves({
-                multihash: 'fakemultihash',
+                vDidId: 'fakevendordidid',
                 marketplaceSignature: 'fakesignature',
                 vendorSignature: null
             }),
-            getKeys: sinon.stub().resolves({
-                pubKeyMultihash: 'fakemultihash'
-            }),
+            getDIDID: sinon.stub().resolves('fakemarketplacedid'),
             createPoPR: sinon.stub().resolves({
                 signature: 'fakesignature'
             }),
@@ -44,7 +42,7 @@ describe('HTTP API', () => {
 
     it('GET /vendors/ven1', async () => {
         await api.get('/vendors/ven1').expect({
-            multihash: 'fakemultihash',
+            vDidId: 'fakevendordidid',
             marketplaceSignature: 'fakesignature',
             vendorSignature: null
         });
@@ -53,7 +51,7 @@ describe('HTTP API', () => {
 
     it('GET /.well-known', async () => {
         await api.get('/.well-known').expect({
-            multihash: 'fakemultihash'
+            didId: 'fakemarketplacedid'
         });
     });
 
@@ -64,7 +62,7 @@ describe('HTTP API', () => {
             })
             .expect({
                 id: 'pvmultihash',
-                multihash: 'fakemultihash',
+                vDidId: 'fakevendordidid',
                 marketplaceSignature: 'fakesignature'
             });
         expect(mkt.registerVendor.calledWith('pvmultihash')).to.be.true;

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -7,21 +7,19 @@ const path = require('path');
 const tmpDir = path.join(require('os').tmpdir(), 'chlu-marketplace-tests');
 const keyFile = path.join(tmpDir, 'chlu-marketplace-key.txt');
 const dbFile = path.join(tmpDir, 'db.sqlite');
-const { ECPair } = require('bitcoinjs-lib');
+const ChluDID = require('chlu-did/src')
 
 describe('Marketplace (Integration)', () => {
-    let mkt;
+    let mkt, DID;
 
     async function getRandomVendor() {
-        const keyPair = ECPair.makeRandom();
-        const multihash = await mkt.chluIpfs.instance.crypto.storePublicKey(keyPair.getPublicKeyBuffer());
-        return {
-            keyPair,
-            multihash
-        };
+        const did = await DID.generateDID()
+        await mkt.chluIpfs.instance.did.publish(did, false)
+        return did
     }
 
     before(async () => {
+        DID = new ChluDID()
         mkt = new Marketplace({
             rootKeyPairPath: keyFile,
             db: {
@@ -29,6 +27,7 @@ describe('Marketplace (Integration)', () => {
                 password: 'test'
             },
             chluIpfs: {
+                network: 'test', // so that it doesn't talk to other nodes
                 logger: {
                     debug: () => {},
                     info: () => {},
@@ -49,6 +48,9 @@ describe('Marketplace (Integration)', () => {
         // Start manually since we call it from outside during the tests
         await mkt.chluIpfs.start();
         const c = mkt.chluIpfs.instance.crypto;
+        const d = mkt.chluIpfs.instance.did
+        sinon.spy(d, 'signMultihash');
+        sinon.spy(d, 'verifyMultihash');
         sinon.spy(c, 'storePublicKey');
         sinon.spy(c, 'signMultihash');
         sinon.spy(c, 'verifyMultihash');
@@ -70,16 +72,16 @@ describe('Marketplace (Integration)', () => {
 
     it('can register a new vendor', async () => {
         const v = await getRandomVendor();
-        const response = await mkt.registerVendor(v.multihash);
-        expect(response.vPubKeyMultihash).to.equal(v.multihash);
+        const response = await mkt.registerVendor(v.publicDidDocument.id);
+        expect(response.vDidId).to.equal(v.publicDidDocument.id);
         // Calls
         expect(mkt.chluIpfs.instance.crypto.storePublicKey.called).to.be.true;
-        expect(mkt.chluIpfs.instance.crypto.signMultihash.called).to.be.true;
+        expect(mkt.chluIpfs.instance.did.signMultihash.called).to.be.true;
         // State
-        const vendor = await mkt.db.getVendor(response.vPubKeyMultihash);
+        const vendor = await mkt.db.getVendor(response.vDidId);
         expect(vendor).to.be.an('object');
-        expect(vendor.vPubKeyMultihash).to.equal(v.multihash);
-        expect(vendor.vmKeyPairWIF)
+        expect(vendor.vDidId).to.equal(v.publicDidDocument.id);
+        expect(vendor.vmPrivateKey)
             .to.be.a('string');
         expect(vendor.vmPubKeyMultihash)
             .to.be.a('string');
@@ -88,50 +90,50 @@ describe('Marketplace (Integration)', () => {
         expect(vendor.vSignature)
             .to.be.null;
         // Response
-        expect(response.vPubKeyMultihash)
-            .to.equal(vendor.vPubKeyMultihash);
+        expect(response.vDidId)
+            .to.equal(vendor.vDidId);
         expect(response.mSignature)
             .to.equal(vendor.mSignature);
         expect(response).to.be.an('object');
         // Verify signatures
-        const mMultihash = (await mkt.getKeys()).pubKeyMultihash;
-        const valid = await mkt.chluIpfs.instance.crypto.verifyMultihash(mMultihash, response.vmPubKeyMultihash, vendor.mSignature);
+        const mDidId = await mkt.getDIDID()
+        const valid = await mkt.chluIpfs.instance.did.verifyMultihash(mDidId, response.vmPubKeyMultihash, vendor.mSignature);
         expect(valid).to.be.true;
     });
 
     it('can submit a vendor signature', async () => {
         const v = await getRandomVendor();
-        const vendorData = await mkt.registerVendor(v.multihash);
-        const signature = await mkt.chluIpfs.instance.crypto.signMultihash(vendorData.vmPubKeyMultihash, v.keyPair);
+        const vendorData = await mkt.registerVendor(v.publicDidDocument.id);
+        const signature = await mkt.chluIpfs.instance.did.signMultihash(vendorData.vmPubKeyMultihash, v.privateKeyBase58);
         await mkt.updateVendorSignature(
-            vendorData.vPubKeyMultihash,
+            vendorData.vDidId,
             signature,
-            v.multihash
+            v.publicDidDocument.id
         );
-        expect(mkt.chluIpfs.instance.crypto.verifyMultihash.calledWith(
-            v.multihash,
+        expect(mkt.chluIpfs.instance.did.verifyMultihash.calledWith(
+            v.publicDidDocument.id,
             vendorData.vmPubKeyMultihash,
             signature
         )).to.be.true;
-        const vendor = await mkt.db.getVendor(vendorData.vPubKeyMultihash);
-        expect(vendor.vPubKeyMultihash).to.equal(v.multihash);
+        const vendor = await mkt.db.getVendor(vendorData.vDidId);
+        expect(vendor.vDidId).to.equal(v.publicDidDocument.id);
         expect(vendor.vSignature).to.equal(signature);
     });
 
     it('can list vendors', async () => {
         const v = await getRandomVendor();
-        await mkt.registerVendor(v.multihash);
+        await mkt.registerVendor(v.publicDidDocument.id);
         const vendors = await mkt.getVendorIDs();
         expect(vendors).to.be.an('Array');
-        expect(vendors.indexOf(v.multihash)).to.be.above(-1);
+        expect(vendors.indexOf(v.publicDidDocument.id)).to.be.above(-1);
     });
 
     it('can retrieve vendor information', async() => {
         const v = await getRandomVendor();
-        await mkt.registerVendor(v.multihash);
-        const vendor = await mkt.getVendor(v.multihash);
+        await mkt.registerVendor(v.publicDidDocument.id);
+        const vendor = await mkt.getVendor(v.publicDidDocument.id);
         // Intentionally check that the keypair is not returned
-        expect(vendor.vPubKeyMultihash).to.equal(v.multihash);
+        expect(vendor.vDidId).to.equal(v.publicDidDocument.id);
         expect(vendor.vmPubKeyMultihash).to.be.a('string');
         expect(vendor.vSignature).to.be.null;
         expect(vendor.mSignature).to.be.a('string');
@@ -140,16 +142,16 @@ describe('Marketplace (Integration)', () => {
     it('can create valid PoPRs', async () => {
         // Vendor full setup
         const v = await getRandomVendor();
-        const vendorData = await mkt.registerVendor(v.multihash);
-        const signature = await mkt.chluIpfs.instance.crypto.signMultihash(vendorData.vmPubKeyMultihash, v.keyPair);
+        const vendorData = await mkt.registerVendor(v.publicDidDocument.id);
+        const signature = await mkt.chluIpfs.instance.did.signMultihash(vendorData.vmPubKeyMultihash, v.privateKeyBase58);
         await mkt.updateVendorSignature(
-            vendorData.vPubKeyMultihash,
+            vendorData.vDidId,
             signature,
-            v.multihash
+            v.publicDidDocument.id
         );
-        const vendor = await mkt.db.getVendor(vendorData.vPubKeyMultihash);
+        const vendor = await mkt.db.getVendor(vendorData.vDidId);
         // Create PoPR
-        const popr = await mkt.createPoPR(v.multihash);
+        const popr = await mkt.createPoPR(v.publicDidDocument.id);
         // Check that the right calls were made
         expect(mkt.chluIpfs.instance.crypto.signPoPR.called).to.be.true;
         // Check the popr content
@@ -167,10 +169,10 @@ describe('Marketplace (Integration)', () => {
         expect(Array.isArray(popr.attributes)).to.be.true;
         expect(popr.signature).to.be.a('string');
         // Check popr validity
-        mkt.chluIpfs.instance.validator.fetchMarketplaceKey = sinon.stub().callsFake(async url => {
+        mkt.chluIpfs.instance.validator.fetchMarketplaceDIDID = sinon.stub().callsFake(async url => {
             // Stub key retrieval from marketplace
             expect(url).to.equal(popr.marketplace_url);
-            return mkt.pubKeyMultihash;
+            return await mkt.getDIDID();
         });
         const valid = await mkt.chluIpfs.instance.validator.validatePoPRSignaturesAndKeys(popr);
         expect(valid).to.be.true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,7 +1395,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
@@ -1427,15 +1427,15 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
 
-bs58@=2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-2.0.0.tgz#72b713bed223a0ac518bbda0e3ce3f4817f39eb5"
-
-bs58@^4.0.0, bs58@^4.0.1:
+bs58@4.0.1, bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   dependencies:
     base-x "^3.0.2"
+
+bs58@=2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-2.0.0.tgz#72b713bed223a0ac518bbda0e3ce3f4817f39eb5"
 
 bs58check@<3.0.0, bs58check@^2.0.0:
   version "2.1.1"
@@ -1690,16 +1690,27 @@ check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
-chlu-ipfs-support@ChluNetwork/chlu-ipfs-support:
+chlu-did@ChluNetwork/chlu-did:
+  version "1.0.0"
+  resolved "https://codeload.github.com/ChluNetwork/chlu-did/tar.gz/67bb48067b0d82d2583999afd3a321174ef10a04"
+  dependencies:
+    brorand "^1.1.0"
+    bs58 "4.0.1"
+    elliptic "^6.4.0"
+    js-sha3 "^0.7.0"
+
+chlu-ipfs-support@ChluNetwork/chlu-ipfs-support#did:
   version "0.1.0"
-  resolved "https://codeload.github.com/ChluNetwork/chlu-ipfs-support/tar.gz/28a99e7eca448740a127035d4a9751671fdbec21"
+  resolved "https://codeload.github.com/ChluNetwork/chlu-ipfs-support/tar.gz/ec7c13ce955c860d1555de98d0feda2505bc0fe3"
   dependencies:
     axios "^0.18.0"
-    bitcoinjs-lib "^3.3.2"
     blockcypher ChluNetwork/node-client
+    brorand "^1.1.0"
+    chlu-did ChluNetwork/chlu-did
     chlu-wallet-support-js ChluNetwork/chlu-wallet-support-js
     commander "^2.15.1"
     debounce-async "^0.0.1"
+    elliptic "^6.4.0"
     ipfs "~0.28.2"
     ipfs-api "^20.0.0"
     libp2p-websocket-star-rendezvous "^0.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,13 +1255,13 @@ block-stream@*:
 
 blockcypher@ChluNetwork/node-client:
   version "0.2.0"
-  resolved "https://codeload.github.com/ChluNetwork/node-client/tar.gz/95b44914d4c771a7c42c15b858ffac97fc8ee071"
+  resolved "https://codeload.github.com/ChluNetwork/node-client/tar.gz/bb334937f8d9fee2fa47c5bb70351e609c29cda0"
   dependencies:
     superagent "^3.8.2"
 
 blockcypher@ChluNetwork/node-client#fixes:
   version "0.2.0"
-  resolved "https://codeload.github.com/ChluNetwork/node-client/tar.gz/3f50c83981a96a63dffe5011196eff38e103cb86"
+  resolved "https://codeload.github.com/ChluNetwork/node-client/tar.gz/ac1ce99c61886a0bfd6f998d5d5ed3ab89ec86a3"
   dependencies:
     superagent "^3.8.2"
 
@@ -1399,7 +1399,13 @@ brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
-browser-resolve@^1.11.2, browser-resolve@^1.7.0:
+browser-resolve@^1.11.2:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  dependencies:
+    resolve "1.1.7"
+
+browser-resolve@^1.7.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
   dependencies:
@@ -1700,8 +1706,8 @@ chlu-did@ChluNetwork/chlu-did:
     js-sha3 "^0.7.0"
 
 chlu-ipfs-support@ChluNetwork/chlu-ipfs-support#did:
-  version "0.1.0"
-  resolved "https://codeload.github.com/ChluNetwork/chlu-ipfs-support/tar.gz/ec7c13ce955c860d1555de98d0feda2505bc0fe3"
+  version "0.2.0"
+  resolved "https://codeload.github.com/ChluNetwork/chlu-ipfs-support/tar.gz/dc4056ac382b9b96dbb3e462f994aef19faf6b80"
   dependencies:
     axios "^0.18.0"
     blockcypher ChluNetwork/node-client
@@ -1879,14 +1885,14 @@ collection-visit@^1.0.0:
     object-visit "^1.0.0"
 
 color-convert@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
   dependencies:
-    color-name "^1.1.1"
+    color-name "1.1.1"
 
-color-name@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
@@ -1917,8 +1923,8 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
 compare-versions@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.2.1.tgz#a49eb7689d4caaf0b6db5220173fd279614000f7"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.0.tgz#af93ea705a96943f622ab309578b9b90586f39c3"
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -2584,8 +2590,8 @@ errno@~0.1.1, errno@~0.1.7:
     prr "~1.0.1"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -2615,8 +2621,8 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 escodegen@^1.6.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.1.tgz#dbae17ef96c8e4bedb1356f4504fa4cc2f7cb7e2"
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.10.0.tgz#f647395de22519fbd0d928ffcf1d17e0dec2603e"
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
@@ -2770,8 +2776,8 @@ ethereumjs-util@^5.0.0:
     secp256k1 "^3.0.1"
 
 ethjs-util@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.4.tgz#1c8b6879257444ef4d3f3fbbac2ded12cd997d93"
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   dependencies:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
@@ -3141,10 +3147,10 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
 
 "fs-ext@github:baudehlo/node-fs-ext#master":
-  version "1.0.0"
-  resolved "https://codeload.github.com/baudehlo/node-fs-ext/tar.gz/f5c9c9ec584937f8b216335d0c36d238b5d187c9"
+  version "1.2.1"
+  resolved "https://codeload.github.com/baudehlo/node-fs-ext/tar.gz/7c9824f3dc330e795aa13359d96252860bd3a684"
   dependencies:
-    nan "^2.0"
+    nan "^2.10.0"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -3535,8 +3541,8 @@ hash-base@^3.0.0:
     safe-buffer "^5.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.4.tgz#8b50e1f35d51bd01e5ed9ece4dbe3549ccfa0a3c"
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
@@ -3701,8 +3707,8 @@ idb-wrapper@^1.5.0:
   resolved "https://registry.yarnpkg.com/idb-wrapper/-/idb-wrapper-1.7.2.tgz#8251afd5e77fe95568b1c16152eb44b396767ea2"
 
 ieee754@^1.1.8:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -4031,8 +4037,8 @@ ipfs-unixfs-engine@~0.24.4:
     sparse-array "^1.3.1"
 
 ipfs-unixfs@~0.1.14:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-0.1.14.tgz#256437fcf642d8ab46b5185582ec4f21e908ef37"
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-0.1.15.tgz#c204da10019daa048eea465ce8f9c6f350ecef00"
   dependencies:
     protons "^1.0.0"
 
@@ -4963,8 +4969,8 @@ jest-validate@^21.2.1:
     pretty-format "^21.2.1"
 
 joi-browser@^13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/joi-browser/-/joi-browser-13.0.1.tgz#06a7b782d94bca6fa0f107138846ea16588b2e7b"
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/joi-browser/-/joi-browser-13.4.0.tgz#b72ba61b610e3f58e51b563a14e0f5225cfb6896"
 
 joi-multiaddr@^1.0.1:
   version "1.0.1"
@@ -5202,8 +5208,8 @@ left-pad@^1.1.3, left-pad@^1.2.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
 length-prefixed-stream@^1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/length-prefixed-stream/-/length-prefixed-stream-1.5.2.tgz#269b29ff76324361727447f1bfacb762e6965a8f"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/length-prefixed-stream/-/length-prefixed-stream-1.6.0.tgz#6aeeecf38a337172ea0472250e90f5e15b8b2334"
   dependencies:
     buffer-alloc-unsafe "^1.0.0"
     readable-stream "^2.0.0"
@@ -5245,7 +5251,7 @@ level-js@^2.2.4, level-js@~2.2.4:
     typedarray-to-buffer "~1.0.0"
     xtend "~2.1.2"
 
-level-js@timkuijsten/level.js#idbunwrapper:
+"level-js@github:timkuijsten/level.js#idbunwrapper":
   version "2.2.3"
   resolved "https://codeload.github.com/timkuijsten/level.js/tar.gz/18e03adab34c49523be7d3d58fafb0c632f61303"
   dependencies:
@@ -6256,8 +6262,8 @@ multicast-dns@^6.2.3:
     thunky "^1.0.2"
 
 multicodec@~0.2.5, multicodec@~0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.2.6.tgz#9d2d6565fbc0815b139dfc906371fc39df4dfddb"
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.2.7.tgz#44dcb902b7ccd8065c4c348fe9987acf14a0679d"
   dependencies:
     varint "^5.0.0"
 
@@ -6279,7 +6285,7 @@ multihashing-async@^0.4.8, multihashing-async@~0.4.6, multihashing-async@~0.4.7,
     murmurhash3js "^3.0.1"
     nodeify "^1.0.1"
 
-multiplex@dignifiedquire/multiplex:
+"multiplex@github:dignifiedquire/multiplex":
   version "6.7.0"
   resolved "https://codeload.github.com/dignifiedquire/multiplex/tar.gz/b5d5edd30454e2c978ee8c52df86f5f4840d2eab"
   dependencies:
@@ -6312,7 +6318,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0, nan@^2.10.0, nan@^2.2.1, nan@^2.9.2:
+nan@^2.10.0, nan@^2.2.1, nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -6384,8 +6390,8 @@ nise@^1.2.0:
     text-encoding "^0.6.4"
 
 nock@^9.0.18:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-9.3.0.tgz#4dcfdd37bd249836754d05bbac5a1f05e12e0f16"
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.3.3.tgz#d9f4cd3c011afeadaf5ccf1b243f6e353781cda0"
   dependencies:
     chai "^4.1.2"
     debug "^3.1.0"
@@ -6398,8 +6404,8 @@ nock@^9.0.18:
     semver "^5.5.0"
 
 node-abi@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.1.tgz#7628c4d4ec4e9cd3764ceb3652f36b2e7f8d4923"
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.3.tgz#43666b7b17e57863e572409edbb82115ac7af28b"
   dependencies:
     semver "^5.4.1"
 
@@ -6806,8 +6812,8 @@ p-forever@^1.0.1:
   resolved "https://registry.yarnpkg.com/p-forever/-/p-forever-1.0.1.tgz#d8da0e9f88b3929e51596c2f8aa50cf2f1ad06ab"
 
 p-limit@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   dependencies:
     p-try "^1.0.0"
 
@@ -7240,8 +7246,8 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24:
-  version "1.1.27"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.27.tgz#2b2c77019db86855170d903532400bf71ee085b6"
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
 
 pull-abortable@^4.1.1:
   version "4.1.1"
@@ -8742,8 +8748,8 @@ table@^4.0.1:
     string-width "^2.1.1"
 
 tar-fs@^1.13.0:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.2.tgz#17e5239747e399f7e77344f5f53365f04af53577"
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
   dependencies:
     chownr "^1.0.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
This PR reworks the marketplace to use DIDs. Not much has changed as far as external APIs, but internally every use of keypairs with the bitcoinjs-lib library had to be changed to the new DID and keypair format.

__Note:__ before merging, we should merge https://github.com/ChluNetwork/chlu-ipfs-support/pull/92 and maybe make a proper release of the chlu main library.