### PR TITLE
first Search implementation

### DIFF
--- a/src/marketplace.js
+++ b/src/marketplace.js
@@ -195,6 +195,16 @@ class Marketplace {
         }
     }
 
+    async searchVendors(query, limit, offset) {
+        await this.start();
+        try {
+            return await this.db.searchVendors(query, limit, offset);
+        } catch (error) {
+            if (error instanceof HttpError) throw error;
+            throw new HttpError(500, 'Error while Searching Vendors: ' + error.message);
+        }
+    }
+
     /**
      * Get the vendor-marketplace key pair for a vendor
      * 

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,13 @@ app.get('/', (req, res) => respond(res, app.locals.mkt.getInfo()));
 app.get('/vendors', async (req, res) => {
     await respond(res, app.locals.mkt.getVendorIDs());
 });
+app.post('/search', async (req, res) => {
+    const query = get(req, 'body.query', {})
+    const limit = get(req, 'body.limit')
+    const offset = get(req, 'body.offset')
+    const result = await app.locals.mkt.searchVendors(query, limit, offset)
+    await respond(res, result)
+})
 app.post('/vendors', async (req, res) => {
     const didId = req.body.didId;
     await respond(res, app.locals.mkt.registerVendor(didId)); 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -19,6 +19,17 @@ describe('HTTP API', () => {
             getVendorIDs: sinon.stub().resolves([
                 'ven1', 'ven2'
             ]),
+            searchVendors: sinon.stub().resolves({
+                count: 2,
+                rows: [
+                    {
+                        vDidId: 'ven1'
+                    },
+                    {
+                        vDidId: 'ven2'
+                    }
+                ]
+            }),
             getVendor: sinon.stub().resolves({
                 vDidId: 'fakevendordidid',
                 marketplaceSignature: 'fakesignature',
@@ -41,6 +52,28 @@ describe('HTTP API', () => {
 
     it('GET /vendors', async () => {
         await api.get('/vendors').expect(['ven1', 'ven2']);
+    });
+
+    it('POST /search', async () => {
+        const body = { query: { test: 'a' }, limit: 10, offset: 2 }
+        await api.post('/search')
+            .send(body)
+            .expect({
+                count: 2,
+                rows: [
+                    {
+                        vDidId: 'ven1'
+                    },
+                    {
+                        vDidId: 'ven2'
+                    }
+                ]
+            });
+        expect(mkt.searchVendors.args[0]).to.deep.equal([
+            { test: 'a' },
+            10,
+            2
+        ])
     });
 
     it('GET /vendors/ven1', async () => {


### PR DESCRIPTION
A new `/search` endpoint allows to seach vendors by arbitrary profile fields

Strings are searched using `like "%value%"` and numbers using equality. I think we will use mostly strings. The query parameters are in AND

I still need to figure out location based search and reputation based.

Also, this endpoint returns the total number of records and accepts limit and offset parameters for pagination. The review listing APIs on the Query server also accept the limit and offset but don't return the total number of records, I should probably correct that if we want pagination in the wallet